### PR TITLE
Fix app not loading when analytics are down

### DIFF
--- a/plugins/umami.client.ts
+++ b/plugins/umami.client.ts
@@ -1,17 +1,18 @@
 import { defineNuxtPlugin } from "#app"
 
-export default defineNuxtPlugin(async (nuxtApp) => {
+export default defineNuxtPlugin(() => {
   const moduleOptions = {
     websiteId: "545e8bc4-f448-4790-8f28-eaa11d690fb4",
     scriptUrl: "https://umami-zernonia.vercel.app/umami.js",
   }
   const options = { ...moduleOptions }
 
-  await loadScript(options)
+    if (!process.dev) {
+      loadScript(options)
+    }
 })
 
 function loadScript(options: any) {
-  return new Promise((resolve, reject) => {
     const head = document.head || document.getElementsByTagName("head")[0]
     const script = document.createElement("script")
 
@@ -20,13 +21,5 @@ function loadScript(options: any) {
     script.dataset.websiteId = options.websiteId
     script.src = options.scriptUrl
 
-    if (!process.dev) {
-      head.appendChild(script)
-
-      script.onload = resolve
-      script.onerror = reject
-    } else {
-      resolve("")
-    }
-  })
+    head.appendChild(script)
 }


### PR DESCRIPTION
- Removed the promise because all the code in this file is synchronous
- Most importantly, removed `script.onerror = reject`, which made your app crash in case of analytics not loading! Analytics are not critical and shouldn't impact the stability of your app
- Moved the `if (!process.dev)` to the parent function to avoid executing code when not needed

**N.B**: Fixes #9 
