### PR TITLE
feat: Add button to copy markdown and twitter formatted texts to clipboard for Admin screen

### DIFF
--- a/components/AdminButtons.vue
+++ b/components/AdminButtons.vue
@@ -1,0 +1,100 @@
+<!-- eslint-disable no-alert -->
+<script setup lang="ts">
+import type { Project, ProjectTable } from '~/types'
+
+const props = defineProps<{
+  data: Project
+}>()
+
+function containsTeamInfo(project: Project): project is ProjectTable {
+  return Object.keys(project).includes('team_info')
+}
+
+function getProject(): ProjectTable {
+  const project = props.data
+
+  if (!project.github_url) {
+    alert('This project does not have a GitHub URL')
+    throw new Error('This project does not have a GitHub URL')
+  }
+
+  if (!containsTeamInfo(project)) {
+    alert('This project does not contain team_info')
+    throw new Error('This project does not contain team_info')
+  }
+
+  if (!project.team_info) {
+    alert('team_info is null')
+    throw new Error('team_info is null')
+  }
+
+  if (project.team_info.length === 0) {
+    alert('team_info is empty')
+    throw new Error('team_info is empty')
+  }
+  return project
+}
+
+/**
+ * Converts the project and author info into a defined format and copies it to the clipboard
+ * @param authorModifier Conversion function for the author
+ * @param projectAndAuthorTextModifier Conversion function for the project and author text
+ */
+async function copyAdminInfoToClipboard({ projectAndAuthorTextModifier: projectAndAuthorConversion, authorModifier: authorConversionFunction }:
+{
+  authorModifier: (user: any) => string
+  projectAndAuthorTextModifier: (project: ProjectTable, authorText: string) => string
+}) {
+  const project = getProject()
+
+  const authorTexts = project.team_info!.map(authorConversionFunction)
+  let authorText: string
+  if (authorTexts.length === 1)
+    authorText = authorTexts[0]
+  else
+    authorText = `${authorTexts.slice(0, authorTexts.length - 1).join(', ')} and ${authorTexts[authorTexts.length - 1]}`
+
+  const text = projectAndAuthorConversion(project, authorText)
+
+  await navigator.clipboard.writeText(text)
+  alert('Copied to clipboard')
+}
+
+async function copyAsMarkdown() {
+  await copyAdminInfoToClipboard({
+    authorModifier: user => `[@${user?.handler}](https://twitter.com/${user?.handler})`,
+    projectAndAuthorTextModifier: (project, authorText) => `[${project.title}](${project.github_url}) - by ${authorText}`,
+  })
+}
+
+async function copyForTweets() {
+  await copyAdminInfoToClipboard({
+    authorModifier: user => `@${user?.handler}`,
+    projectAndAuthorTextModifier: (project, authorText) => `${project.title}: ${project.github_url} by ${authorText}`,
+  })
+}
+</script>
+
+<template>
+  <div class="flex justify-end pt-4">
+    <UTooltip text="Copy Product and author as Markdown">
+      <UButton
+        icon="i-lucide-copy"
+        variant="ghost"
+        color="gray"
+        label="Copy for Tweets"
+        @click="copyAsMarkdown"
+      />
+    </UTooltip>
+
+    <UTooltip text="Copy Product and author for tweets">
+      <UButton
+        icon="i-lucide-copy"
+        variant="ghost"
+        color="gray"
+        label="Copy as Markdown"
+        @click="copyForTweets"
+      />
+    </UTooltip>
+  </div>
+</template>

--- a/components/AdminView.client.vue
+++ b/components/AdminView.client.vue
@@ -58,7 +58,7 @@ async function downloadCSV() {
     <div class="mt-6">
       <Loading v-if="pending" :loading="pending" />
       <div v-else-if="data?.length" class=" card-grid">
-        <Card v-for="item in data" :key="item.id!" :item="item" />
+        <Card v-for="item in data" :key="item.id!" :item="item" :is-admin="true" />
       </div>
     </div>
   </div>

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -8,6 +8,7 @@ const props = withDefaults(defineProps<{
   item?: Project
   showModal?: boolean
   path?: string
+  isAdmin?: boolean
 }>(), {
   item: undefined,
   showModal: true,
@@ -33,6 +34,7 @@ function handleUserClick(ev: Event) {
     routeModal.value = {
       isOpen: true,
       path: `/p/${props.item?.slug}`,
+      isAdmin: props.isAdmin,
     }
   }
 }

--- a/components/Product.vue
+++ b/components/Product.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable no-alert -->
 <script setup lang="ts">
-import type { Database, Project } from '@/types'
+import type { Project, ProjectTable } from '@/types'
 
 const props = defineProps<{
   data: Project
@@ -23,37 +23,72 @@ const computedUrl = computed(() => {
   return url.href
 })
 
-function containsTeamInfo(value: Project): value is Database['public']['Tables']['products']['Row'] {
-  return Object.keys(value).includes('team_info')
+function containsTeamInfo(project: Project): project is ProjectTable {
+  return Object.keys(project).includes('team_info')
 }
 
-async function copyProjectInfoToClipboard() {
+function getProject(): ProjectTable {
   const project = data.value
-  if (!project.github_url)
-    return alert('This project does not have a GitHub URL')
 
-  if (!containsTeamInfo(project))
-    return alert('This project does not contain team_info')
+  if (!project.github_url) {
+    alert('This project does not have a GitHub URL')
+    throw new Error('This project does not have a GitHub URL')
+  }
 
-  if (!project.team_info)
-    return alert('team_info is null')
+  if (!containsTeamInfo(project)) {
+    alert('This project does not contain team_info')
+    throw new Error('This project does not contain team_info')
+  }
 
-  if (project.team_info.length === 0)
-    return alert('team_info is empty')
+  if (!project.team_info) {
+    alert('team_info is null')
+    throw new Error('team_info is null')
+  }
 
-  const authorTexts = project.team_info.map(
-    (user: any) => `[@${user?.handler}](https://twitter.com/${user?.handler})`,
-  )
+  if (project.team_info.length === 0) {
+    alert('team_info is empty')
+    throw new Error('team_info is empty')
+  }
+  return project
+}
 
+/**
+ * Converts the project and author info into a defined format and copies it to the clipboard
+ * @param authorModifier Conversion function for the author
+ * @param projectAndAuthorTextModifier Conversion function for the project and author text
+ */
+async function copyAdminInfoToClipboard({ projectAndAuthorTextModifier: projectAndAuthorConversion, authorModifier: authorConversionFunction }:
+{
+  authorModifier: (user: any) => string
+  projectAndAuthorTextModifier: (project: ProjectTable, authorText: string) => string
+}) {
+  const project = getProject()
+
+  const authorTexts = project.team_info!.map(authorConversionFunction)
   let authorText: string
   if (authorTexts.length === 1)
     authorText = authorTexts[0]
   else
     authorText = `${authorTexts.slice(0, authorTexts.length - 1).join(', ')} and ${authorTexts[authorTexts.length - 1]}`
 
-  await navigator.clipboard.writeText(`[${project.title}](${project.github_url}) - by ${authorText}`)
+  const text = projectAndAuthorConversion(project, authorText)
 
+  await navigator.clipboard.writeText(text)
   alert('Copied to clipboard')
+}
+
+async function copyAsMarkdown() {
+  await copyAdminInfoToClipboard({
+    authorModifier: user => `[@${user?.handler}](https://twitter.com/${user?.handler})`,
+    projectAndAuthorTextModifier: (project, authorText) => `[${project.title}](${project.github_url}) - by ${authorText}`,
+  })
+}
+
+async function copyForTweets() {
+  await copyAdminInfoToClipboard({
+    authorModifier: user => `@${user?.handler}`,
+    projectAndAuthorTextModifier: (project, authorText) => `${project.title}: ${project.github_url} by ${authorText}`,
+  })
 }
 
 onMounted(() => {
@@ -82,16 +117,6 @@ onMounted(() => {
       />
 
       <div class="flex items-center gap-2 mt-4 justify-end">
-        <UTooltip v-show="isAdmin" text="Copy Product and author as Markdown">
-          <UButton
-            icon="i-lucide-copy"
-            variant="ghost"
-            color="gray"
-            label="Copy as Markdown"
-            @click="copyProjectInfoToClipboard"
-          />
-        </UTooltip>
-
         <LegoSocialShare>
           <LegoSocialShareTwitter
             :text="tweetText"
@@ -128,6 +153,28 @@ onMounted(() => {
 
         <UButton :to="computedUrl" size="md" target="_blank" label="Visit Website" />
       </div>
+    </div>
+
+    <div v-show="isAdmin" class="flex justify-end pt-4">
+      <UTooltip text="Copy Product and author as Markdown">
+        <UButton
+          icon="i-lucide-copy"
+          variant="ghost"
+          color="gray"
+          label="Copy for Tweets"
+          @click="copyAsMarkdown"
+        />
+      </UTooltip>
+
+      <UTooltip text="Copy Product and author for tweets">
+        <UButton
+          icon="i-lucide-copy"
+          variant="ghost"
+          color="gray"
+          label="Copy as Markdown"
+          @click="copyForTweets"
+        />
+      </UTooltip>
     </div>
 
     <div class="mt-6 md:mt-12 w-full flex flex-col placeholder-rose-50">

--- a/components/Product.vue
+++ b/components/Product.vue
@@ -1,9 +1,11 @@
+<!-- eslint-disable no-alert -->
 <script setup lang="ts">
-import type { Project } from '@/types'
+import type { Database, Project } from '@/types'
 
 const props = defineProps<{
   data: Project
   isModal?: boolean
+  isAdmin?: boolean
 }>()
 const { data } = toRefs(props)
 
@@ -20,6 +22,39 @@ const computedUrl = computed(() => {
   url.searchParams.set('ref', 'madewithsupabase')
   return url.href
 })
+
+function containsTeamInfo(value: Project): value is Database['public']['Tables']['products']['Row'] {
+  return Object.keys(value).includes('team_info')
+}
+
+async function copyProjectInfoToClipboard() {
+  const project = data.value
+  if (!project.github_url)
+    return alert('This project does not have a GitHub URL')
+
+  if (!containsTeamInfo(project))
+    return alert('This project does not contain team_info')
+
+  if (!project.team_info)
+    return alert('team_info is null')
+
+  if (project.team_info.length === 0)
+    return alert('team_info is empty')
+
+  const authorTexts = project.team_info.map(
+    (user: any) => `[@${user?.handler}](https://twitter.com/${user?.handler})`,
+  )
+
+  let authorText: string
+  if (authorTexts.length === 1)
+    authorText = authorTexts[0]
+  else
+    authorText = `${authorTexts.slice(0, authorTexts.length - 1).join(', ')} and ${authorTexts[authorTexts.length - 1]}`
+
+  await navigator.clipboard.writeText(`[${project.title}](${project.github_url}) - by ${authorText}`)
+
+  alert('Copied to clipboard')
+}
 
 onMounted(() => {
   $fetch(`/api/view/${data.value.slug}`)
@@ -47,6 +82,16 @@ onMounted(() => {
       />
 
       <div class="flex items-center gap-2 mt-4 justify-end">
+        <UTooltip v-show="isAdmin" text="Copy Product and author as Markdown">
+          <UButton
+            icon="i-lucide-copy"
+            variant="ghost"
+            color="gray"
+            label="Copy as Markdown"
+            @click="copyProjectInfoToClipboard"
+          />
+        </UTooltip>
+
         <LegoSocialShare>
           <LegoSocialShareTwitter
             :text="tweetText"

--- a/components/Product.vue
+++ b/components/Product.vue
@@ -1,6 +1,5 @@
-<!-- eslint-disable no-alert -->
 <script setup lang="ts">
-import type { Project, ProjectTable } from '@/types'
+import type { Project } from '@/types'
 
 const props = defineProps<{
   data: Project
@@ -22,74 +21,6 @@ const computedUrl = computed(() => {
   url.searchParams.set('ref', 'madewithsupabase')
   return url.href
 })
-
-function containsTeamInfo(project: Project): project is ProjectTable {
-  return Object.keys(project).includes('team_info')
-}
-
-function getProject(): ProjectTable {
-  const project = data.value
-
-  if (!project.github_url) {
-    alert('This project does not have a GitHub URL')
-    throw new Error('This project does not have a GitHub URL')
-  }
-
-  if (!containsTeamInfo(project)) {
-    alert('This project does not contain team_info')
-    throw new Error('This project does not contain team_info')
-  }
-
-  if (!project.team_info) {
-    alert('team_info is null')
-    throw new Error('team_info is null')
-  }
-
-  if (project.team_info.length === 0) {
-    alert('team_info is empty')
-    throw new Error('team_info is empty')
-  }
-  return project
-}
-
-/**
- * Converts the project and author info into a defined format and copies it to the clipboard
- * @param authorModifier Conversion function for the author
- * @param projectAndAuthorTextModifier Conversion function for the project and author text
- */
-async function copyAdminInfoToClipboard({ projectAndAuthorTextModifier: projectAndAuthorConversion, authorModifier: authorConversionFunction }:
-{
-  authorModifier: (user: any) => string
-  projectAndAuthorTextModifier: (project: ProjectTable, authorText: string) => string
-}) {
-  const project = getProject()
-
-  const authorTexts = project.team_info!.map(authorConversionFunction)
-  let authorText: string
-  if (authorTexts.length === 1)
-    authorText = authorTexts[0]
-  else
-    authorText = `${authorTexts.slice(0, authorTexts.length - 1).join(', ')} and ${authorTexts[authorTexts.length - 1]}`
-
-  const text = projectAndAuthorConversion(project, authorText)
-
-  await navigator.clipboard.writeText(text)
-  alert('Copied to clipboard')
-}
-
-async function copyAsMarkdown() {
-  await copyAdminInfoToClipboard({
-    authorModifier: user => `[@${user?.handler}](https://twitter.com/${user?.handler})`,
-    projectAndAuthorTextModifier: (project, authorText) => `[${project.title}](${project.github_url}) - by ${authorText}`,
-  })
-}
-
-async function copyForTweets() {
-  await copyAdminInfoToClipboard({
-    authorModifier: user => `@${user?.handler}`,
-    projectAndAuthorTextModifier: (project, authorText) => `${project.title}: ${project.github_url} by ${authorText}`,
-  })
-}
 
 onMounted(() => {
   $fetch(`/api/view/${data.value.slug}`)
@@ -155,27 +86,7 @@ onMounted(() => {
       </div>
     </div>
 
-    <div v-show="isAdmin" class="flex justify-end pt-4">
-      <UTooltip text="Copy Product and author as Markdown">
-        <UButton
-          icon="i-lucide-copy"
-          variant="ghost"
-          color="gray"
-          label="Copy for Tweets"
-          @click="copyAsMarkdown"
-        />
-      </UTooltip>
-
-      <UTooltip text="Copy Product and author for tweets">
-        <UButton
-          icon="i-lucide-copy"
-          variant="ghost"
-          color="gray"
-          label="Copy as Markdown"
-          @click="copyForTweets"
-        />
-      </UTooltip>
-    </div>
+    <AdminButtons v-if="isAdmin" :data="data" />
 
     <div class="mt-6 md:mt-12 w-full flex flex-col placeholder-rose-50">
       <Marked

--- a/components/RouteModal/Product.vue
+++ b/components/RouteModal/Product.vue
@@ -10,7 +10,7 @@ const data = computed(() =>
 <template>
   <RouteModalCommon>
     <div class="p-4 md:p-12">
-      <Product v-if="data" is-modal :data="data" />
+      <Product v-if="data" is-modal :data="data" :is-admin="routeModal.isAdmin" />
     </div>
   </RouteModalCommon>
 </template>

--- a/composables/useRouteModal.ts
+++ b/composables/useRouteModal.ts
@@ -2,5 +2,6 @@ export function useRouteModal() {
   return useState('route-modal', () => ({
     isOpen: false,
     path: '',
+    isAdmin: false,
   }))
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -15,3 +15,5 @@ export type NonNullableProjectForm = {
     email: string
   }[]
 }
+
+export type ProjectTable = Database['public']['Tables']['products']['Row']


### PR DESCRIPTION
Adding a handy feature to the admin screen.

Often times, we need to extract the project's information to compose tweets or articles after hackathons. It currently required one to download the projects as CSV and carefully putting the information together. 

With this PR, we now have two new buttons in the admin screen that allows one to easily copy the necessary information into the clip board. 

<img width="414" alt="Screenshot 2024-01-05 at 16 47 36" src="https://github.com/zernonia/madewithsupabase/assets/18113850/d40116c6-a1ad-4329-a103-9e9bb72efc4e">
